### PR TITLE
Handle cases where the dns entry doesn't exist yet

### DIFF
--- a/image/custom-entrypoint.sh
+++ b/image/custom-entrypoint.sh
@@ -5,11 +5,14 @@
 my_ip=$(hostname --ip-address)
 
 CASSANDRA_SEEDS=$(host $PEER_DISCOVERY_SERVICE | \
+    grep -v "not found" | \
     grep -v $my_ip | \
     sort | \
     head -2 | xargs | \
     awk '{print $4}')
 
-export CASSANDRA_SEEDS
+if [ ! -z "$CASSANDRA_SEEDS" ]; then
+    export CASSANDRA_SEEDS
+fi
 
 /docker-entrypoint.sh "$@"


### PR DESCRIPTION
host can return "Host cassandra-peers not found: 3(NXDOMAIN)" sometimes,
we need to check this so we don't end up with CASSANDRA_SEEDS="found:"
